### PR TITLE
fix(test): Enable operator schema filter test on Cloudberry

### DIFF
--- a/integration/predata_operators_queries_test.go
+++ b/integration/predata_operators_queries_test.go
@@ -55,15 +55,38 @@ var _ = Describe("backup integration tests", func() {
 
 		})
 		It("returns a slice of operators from a specific schema", func() {
-			testhelper.AssertQueryRuns(connectionPool, "CREATE OPERATOR public.## (LEFTARG = bigint, PROCEDURE = numeric_fac)")
-			defer testhelper.AssertQueryRuns(connectionPool, "DROP OPERATOR public.## (bigint, NONE)")
+			// Cloudberry does not support postfix operators, which this test originally required.
+			// To ensure this test for schema filtering runs on all platforms, we refactor it
+			// to use a binary operator, which is supported by both Greenplum and Cloudberry.
+			testhelper.AssertQueryRuns(connectionPool, "CREATE FUNCTION public.binary_op_func(bigint, bigint) RETURNS bigint AS 'SELECT $1 + $2' LANGUAGE SQL IMMUTABLE;")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.binary_op_func(bigint, bigint);")
+
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SCHEMA testschema")
-			testhelper.AssertQueryRuns(connectionPool, "CREATE OPERATOR testschema.## (LEFTARG = bigint, PROCEDURE = numeric_fac)")
-			defer testhelper.AssertQueryRuns(connectionPool, "DROP OPERATOR testschema.## (bigint, NONE)")
+
+			// Create one operator in 'public' (to be filtered out) and one in 'testschema' (to be included).
+			testhelper.AssertQueryRuns(connectionPool, "CREATE OPERATOR public.## (LEFTARG = bigint, RIGHTARG = bigint, PROCEDURE = public.binary_op_func)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP OPERATOR public.## (bigint, bigint)")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE OPERATOR testschema.## (LEFTARG = bigint, RIGHTARG = bigint, PROCEDURE = public.binary_op_func)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP OPERATOR testschema.## (bigint, bigint)")
+
 			_ = backupCmdFlags.Set(options.INCLUDE_SCHEMA, "testschema")
 
-			expectedOperator := backup.Operator{Oid: 0, Schema: "testschema", Name: "##", Procedure: "numeric_fac", LeftArgType: "bigint", RightArgType: "-", CommutatorOp: "0", NegatorOp: "0", RestrictFunction: "-", JoinFunction: "-", CanHash: false, CanMerge: false}
+			// The underlying SQL query normalizes the output, so we expect the same result across all supported versions.
+			expectedOperator := backup.Operator{
+				Oid:              0,
+				Schema:           "testschema",
+				Name:             "##",
+				Procedure:        "public.binary_op_func",
+				LeftArgType:      "bigint",
+				RightArgType:     "bigint",
+				CommutatorOp:     "0",
+				NegatorOp:        "0",
+				RestrictFunction: "-",
+				JoinFunction:     "-",
+				CanHash:          false,
+				CanMerge:         false,
+			}
 
 			results := backup.GetOperators(connectionPool)
 


### PR DESCRIPTION
The test for schema-filtered operators would previously fail when run against a Cloudberry instance. This was because it relied on creating a postfix (unary) operator, a feature not supported by Cloudberry.

This commit refactors the test to use a binary operator instead. Binary operators are supported by both Greenplum and Cloudberry, which allows the test for this core schema-filtering functionality to run successfully on all platforms.

This change fixes a failing test and increases test coverage for a core feature on Cloudberry.