### PR TITLE
fix(test): Adapt role password test for Cloudberry

### DIFF
--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -344,6 +344,16 @@ CREATEEXTTABLE (protocol='gphdfs', type='writable')`
 
 			for _, role := range results {
 				if role.Name == "role1" {
+					if connectionPool.Version.IsCBDB() {
+						// Cloudberry uses SCRAM-SHA-256 by default, while the test was
+						// written expecting an MD5 hash. The exact SCRAM hash is
+						// unpredictable due to salting, so we only check its prefix.
+						Expect(role.Password).To(HavePrefix("SCRAM-SHA-256$"))
+						// After checking the prefix, we clear both password fields to prevent
+						// the structmatcher from performing a failing string comparison.
+						expectedRole.Password = ""
+						role.Password = ""
+					}
 					structmatcher.ExpectStructsToMatchExcluding(&expectedRole, role, "TimeConstraints.Oid")
 					return
 				}


### PR DESCRIPTION
The integration test for `GetDatabaseRoles` was failing on Cloudberry because the expected password hash format did not match the actual value returned by the database.

The test was hard-coded to expect an MD5 password hash, but the Cloudberry instance uses the more secure SCRAM-SHA-256 by default(PostgreSQL 14). This resulted in a string mismatch failure.

This commit adapts the test to handle this difference specifically for Cloudberry. When running against a Cloudberry instance, the test now:
1. Asserts that the returned password hash has the "SCRAM-SHA-256$" prefix, confirming the correct algorithm is used.
2. Clears the password fields from both the expected and actual structs before the final comparison, as the full salted hash is unpredictable.

The test logic for all Greenplum versions remains unchanged, preserving the original MD5 hash validation for those environments.