### PR TITLE
fix(test): adjust stored procedure test expectations for Cloudberry

### DIFF
--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -427,6 +427,16 @@ INSERT INTO public.tbl VALUES (b);
 				secondProcedure.DataAccess = ""
 			}
 
+			// In Cloudberry (PostgreSQL 14+), pg_get_function_arguments returns the parameter
+			// mode (e.g., 'IN') for procedures, which differs from GPDB 7. We adjust the
+			// expected values accordingly.
+			if connectionPool.Version.IsCBDB() {
+				firstProcedure.Arguments.String = "IN a integer, IN b integer"
+				firstProcedure.IdentArgs.String = "IN a integer, IN b integer"
+				secondProcedure.Arguments.String = "IN a integer, IN b integer"
+				secondProcedure.IdentArgs.String = "IN a integer, IN b integer"
+			}
+
 			Expect(results).To(HaveLen(2))
 			structmatcher.ExpectStructsToMatchExcluding(&results[0], &firstProcedure, "Oid")
 			structmatcher.ExpectStructsToMatchExcluding(&results[1], &secondProcedure, "Oid")


### PR DESCRIPTION
The integration test for stored procedures was failing on Cloudberry due to differences in pg_get_function_arguments behavior compared to GPDB 7.

In Cloudberry (based onPostgreSQL 14), pg_get_function_arguments includes parameter modes (e.g., "IN") in the returned arguments string, while GPDB 7 omits them.

This commit updates the test to expect the correct format for each database version:
- Cloudberry: "IN a integer, IN b integer"
- GPDB 7: "a integer, b integer"

The underlying gpbackup functionality works correctly on both platforms; only the test expectations needed adjustment.

Fixes: Integration test failure in predata_functions_queries_test.go