### PR TITLE
fix(backup): Use standard LOCK TABLE syntax for Cloudberry

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -371,7 +371,13 @@ func GetBackupDataSet(tables []Table) ([]Table, int64) {
 // the lock, the call will fail instead of block. Return the failure for handling.
 func LockTableNoWait(dataTable Table, connNum int) error {
 	var lockMode string
-	if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB() {
+	// TODO: This is a temporary workaround. Cloudberry should support the
+	// COORDINATOR ONLY syntax to align with GPDB 7+ for performance optimization
+	// during the table locking phase. Revert this to the combined GPDB 7+ condition
+	// once Cloudberry adds this feature.
+	if connectionPool.Version.IsCBDB() {
+		lockMode = `IN ACCESS SHARE MODE NOWAIT`
+	} else if connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7") {
 		lockMode = `IN ACCESS SHARE MODE NOWAIT COORDINATOR ONLY`
 	} else if connectionPool.Version.AtLeast("6.21.0") {
 		lockMode = `IN ACCESS SHARE MODE NOWAIT MASTER ONLY`

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -486,7 +486,13 @@ func LockTables(connectionPool *dbconn.DBConn, tables []Relation) {
 	lastBatchSize := len(tables) % batchSize
 	tableBatches := GenerateTableBatches(tables, batchSize)
 	currentBatchSize := batchSize
-	if (connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB() {
+	// TODO: This is a temporary workaround. Cloudberry should support the
+	// COORDINATOR ONLY syntax to align with GPDB 7+ for performance optimization
+	// during the table locking phase. Revert this to the combined GPDB 7+ condition
+	// once Cloudberry adds this feature.
+	if connectionPool.Version.IsCBDB() {
+		lockMode = `IN ACCESS SHARE MODE`
+	} else if connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7") {
 		lockMode = `IN ACCESS SHARE MODE COORDINATOR ONLY`
 	} else if connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("6.21.0") {
 		lockMode = `IN ACCESS SHARE MODE MASTER ONLY`


### PR DESCRIPTION
Temporarily modifies the table locking logic to use a standard `LOCK TABLE ... IN ACCESS SHARE MODE` command when running against Cloudberry.

This change is necessary because Cloudberry, which is based on PostgreSQL 14, does not support the `COORDINATOR ONLY` clause that was introduced in GPDB 7 as a performance optimization. The use of this unsupported syntax was causing `gpbackup` to panic during the initial table locking phase.

A TODO comment has been added to both modified functions (`LockTables` and `LockTableNoWait`) to indicate that this is a workaround. The logic should be reverted to use the `COORDINATOR ONLY` optimization once Cloudberry implements this feature for feature and performance parity with GPDB 7.

See https://github.com/apache/cloudberry/issues/1265