### PR TITLE
fix(test): adjust GetProceduralLanguages test expectations for Cloudberry

### DIFF
--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -827,7 +827,16 @@ LANGUAGE SQL`)
 			}
 
 			testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("CREATE LANGUAGE %su", plpythonString))
-			defer testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("DROP LANGUAGE %su", plpythonString))
+
+			// In Cloudberry (PG14+), a direct `CREATE LANGUAGE` command for a language
+			// like plpython3u implicitly links it to its corresponding extension, making
+			// it a core extension member. Therefore, it must be cleaned up by dropping
+			// the extension, not the language.
+			if connectionPool.Version.IsCBDB() {
+				defer testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("DROP EXTENSION IF EXISTS %su CASCADE", plpythonString))
+			} else {
+				defer testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("DROP LANGUAGE %su", plpythonString))
+			}
 
 			pythonHandlerOid := testutils.OidFromObjectName(connectionPool, "pg_catalog", fmt.Sprintf("%s_call_handler", plpythonString), backup.TYPE_FUNCTION)
 
@@ -842,8 +851,15 @@ LANGUAGE SQL`)
 
 			resultProcLangs := backup.GetProceduralLanguages(connectionPool)
 
-			Expect(resultProcLangs).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&expectedPlpythonInfo, &resultProcLangs[0], "Oid", "Owner")
+			// The GetProceduralLanguages function correctly filters out languages that are
+			// core members of an extension. Since the `CREATE LANGUAGE` command on
+			// Cloudberry creates such a language, we expect the result to have a length of 0.
+			if connectionPool.Version.IsCBDB() {
+				Expect(resultProcLangs).To(HaveLen(0))
+			} else {
+				Expect(resultProcLangs).To(HaveLen(1))
+				structmatcher.ExpectStructsToMatchExcluding(&expectedPlpythonInfo, &resultProcLangs[0], "Oid", "Owner")
+			}
 		})
 	})
 	Describe("GetConversions", func() {


### PR DESCRIPTION
The `GetProceduralLanguages` integration test was failing on Cloudberry (PostgreSQL 14) because it expected a manually created procedural language to be returned, but the function was correctly filtering it out.

In PostgreSQL 14, `CREATE LANGUAGE plpython3u` implicitly links the language to the `plpython3u` extension, registering it in `pg_depend` with `deptype = 'e'` (core extension member). The `GetProceduralLanguages` function is designed to filter out these members to prevent duplicate entries during backup, as they are restored via `CREATE EXTENSION`.

This commit adapts the test to reflect this correct behavior on Cloudberry:
- The test now asserts that `GetProceduralLanguages` returns a list of length 0 on Cloudberry, validating the filtering logic.
- The cleanup logic is updated to use `DROP EXTENSION` instead of `DROP LANGUAGE` on Cloudberry, as the latter would fail.

This change makes the test more robust by verifying the distinct language handling behaviors between GPDB and Cloudberry.