### PR TITLE
Fix: Correctly handle base array type creation on Cloudberry

### DIFF
--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -117,6 +117,9 @@ func PrintCreateBaseTypeStatement(metadataFile *utils.FileWithByteCount, objToc 
 	if base.Element != "" {
 		metadataFile.MustPrintf(",\n\tELEMENT = %s", base.Element)
 	}
+	if base.Subscript != "" {
+		metadataFile.MustPrintf(",\n\tSUBSCRIPT = %s", base.Subscript)
+	}
 	if base.Delimiter != "" {
 		metadataFile.MustPrintf(",\n\tDELIMITER = '%s'", base.Delimiter)
 	}

--- a/integration/predata_types_queries_test.go
+++ b/integration/predata_types_queries_test.go
@@ -139,10 +139,19 @@ var _ = Describe("backup integration tests", func() {
 			}
 
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.base_array_type")
-			defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.base_array_type CASCADE")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE FUNCTION public.base_array_fn_in(cstring) RETURNS public.base_array_type AS 'boolin' LANGUAGE internal")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE FUNCTION public.base_array_fn_out(public.base_array_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.base_array_type(INPUT=public.base_array_fn_in, OUTPUT=public.base_array_fn_out, ELEMENT=text)")
+			if connectionPool.Version.IsCBDB() {
+				// For Cloudberry (based on PG14), creating a type with an ELEMENT requires a SUBSCRIPT function.
+				testhelper.AssertQueryRuns(connectionPool, "CREATE FUNCTION public.base_array_subscript_handler(internal) RETURNS internal AS 'array_subscript_handler' LANGUAGE internal")
+				defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.base_array_subscript_handler(internal)")
+				testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.base_array_type(INPUT=public.base_array_fn_in, OUTPUT=public.base_array_fn_out, ELEMENT=text, SUBSCRIPT=public.base_array_subscript_handler)")
+				arrayType.Subscript = "public.base_array_subscript_handler"
+			} else {
+				// For GPDB (based on PG12 or earlier), this is not required.
+				testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.base_array_type(INPUT=public.base_array_fn_in, OUTPUT=public.base_array_fn_out, ELEMENT=text)")
+			}
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.base_array_type CASCADE")
 
 			results := backup.GetBaseTypes(connectionPool)
 


### PR DESCRIPTION
The integration test for user-created array types was failing on Cloudberry. This was due to two related issues stemming from Cloudberry being based on a newer PostgreSQL version (PG14) than Greenplum 7 (PG12).

First, creating a base type with an `ELEMENT` attribute on Cloudberry requires a `SUBSCRIPT` function to be provided, a stricter requirement than in Greenplum. The integration test in `predata_types_queries_test.go` is updated to add this `SUBSCRIPT` function only when running against a Cloudberry instance.

Second, the `pg_type` system catalog in Cloudberry contains a `typsubscript` column which is absent in Greenplum 7. The previous metadata query was failing to retrieve this information. A dedicated query for Cloudberry has been added in `backup/queries_types.go` to fetch this field, with the `GetBaseTypes` function now using the appropriate query based on the database connection.