### PR TITLE
fix(backup): Enable modern sequence and constraint features for Cloudberry

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -318,7 +318,8 @@ func generateSequenceDefinitionStatement(sequence Sequence) string {
 	minVal := int64(math.MinInt64)
 
 	// Identity columns cannot be defined with `AS smallint/integer`
-	if connectionPool.Version.AtLeast("7") && sequence.OwningColumnAttIdentity == "" {
+	if ((connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) || connectionPool.Version.IsCBDB()) &&
+		sequence.OwningColumnAttIdentity == "" {
 		if definition.Type != "bigint" {
 			statement += fmt.Sprintf("\n\tAS %s", definition.Type)
 		}

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -273,7 +273,8 @@ func retrieveAndBackupTypes(metadataFile *utils.FileWithByteCount, sortables *[]
 func retrieveConstraints(sortables *[]Sortable, metadataMap MetadataMap, tables ...Relation) ([]Constraint, []Constraint, MetadataMap) {
 	gplog.Verbose("Retrieving constraints")
 	constraints := GetConstraints(connectionPool, tables...)
-	if len(constraints) > 0 && connectionPool.Version.AtLeast("7") {
+	if len(constraints) > 0 && ((connectionPool.Version.IsGPDB() && connectionPool.Version.AtLeast("7")) ||
+		connectionPool.Version.IsCBDB()) {
 		RenameExchangedPartitionConstraints(connectionPool, &constraints)
 	}
 


### PR DESCRIPTION
The logic for handling modern sequence definitions (`AS <type>`) and renaming constraints on exchanged partitions was previously gated for GPDB 7+ only.

This caused incorrect backups on Cloudberry, which supports these modern PostgreSQL capabilities but was not included in the version check. Consequently, sequence types could be lost, and exchanged partition constraints could have incorrect names, leading to potential restore failures.

This commit updates the version checks to the standard `(IsGPDB() && AtLeast("7")) || IsCBDB()` pattern. This ensures these critical features execute correctly for Cloudberry, improving backup correctness and reliability.
