### PR TITLE
fix(test): Skip resize cluster test for Cloudberry due to replicated table issue

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2288,6 +2288,14 @@ LANGUAGE plpgsql NO SQL;`)
 					if useOldBackupVersion {
 						Skip("Resize-cluster was only added in version 1.26")
 					}
+
+					// TODO: Re-enable this test for Cloudberry once the following issue is fixed:
+					// https://github.com/apache/cloudberry/issues/1298
+					if restoreConn.Version.IsCBDB() {
+						Skip(`This test is skipped for Cloudberry due to an issue with COPY FROM ON SEGMENT for
+							replicated tables (https://github.com/apache/cloudberry/issues/1298).`)
+					}
+
 					extractDirectory := extractSavedTarFile(backupDir, tarBaseName)
 					defer testhelper.AssertQueryRuns(restoreConn, `DROP SCHEMA IF EXISTS schemaone CASCADE;`)
 

--- a/restore/data.go
+++ b/restore/data.go
@@ -140,6 +140,13 @@ func restoreSingleTableData(fpInfo *filepath.FilePathInfo, entry toc.Coordinator
 		numRowsRestored /= int64(destSize)
 	}
 
+	// TODO: When restoring a replicated table to a cluster with a different number of segments (resize),
+	// this check may fail for Cloudberry. This is because gprestore assumes that the COPY
+	// command for a replicated table returns the total number of rows copied across all segments
+	// (N * rows_per_segment) and divides the result by N to get the actual row count.
+	// However, due to Cloudberry issue https://github.com/apache/cloudberry/issues/1298,
+	// its COPY ON SEGMENT command returns only the base row count (rows_per_segment).
+	// The subsequent division in gprestore leads to a miscalculated row count, causing this check to fail.
 	err := CheckRowsRestored(numRowsRestored, numRowsBackedUp, tableName)
 	if err != nil {
 		gplog.Error(err.Error())


### PR DESCRIPTION
Skip resize cluster test in end-to-end suite for Cloudberry due to COPY FROM ON SEGMENT issue with replicated tables. Add detailed TODO comment in restore/data.go explaining the root cause of row count validation failures during resize operations.

References Cloudberry issue #1298 for tracking the upstream fix. Ensures test stability while maintaining compatibility with Greenplum behavior.

The test is temporarily disabled for Cloudberry until the upstream issue with COPY command returning incorrect row counts for replicated tables is resolved.

See: https://github.com/apache/cloudberry/issues/1298
