### PR TITLE
fix(tests): Use compatible operator for legacy script

### DIFF
--- a/end_to_end/resources/gpdb4_objects.sql
+++ b/end_to_end/resources/gpdb4_objects.sql
@@ -99,8 +99,9 @@ CREATE AGGREGATE agg_test(integer) (
 
 
 CREATE OPERATOR #### (
-    PROCEDURE = numeric_fac,
-    LEFTARG = bigint
+    PROCEDURE = int8pl,
+    LEFTARG = bigint,
+    RIGHTARG = bigint
 );
 
 


### PR DESCRIPTION
The `gpdb4_objects.sql` script failed on certain database versions as it defined a postfix operator, a feature no longer supported.

To ensure compatibility, the unsupported postfix operator has been replaced with a standard binary operator definition. This allows the test to validate the backup and restore of operator metadata across all supported database versions.

This change is safe as the test's purpose is to check the handling of the operator's metadata, not its runtime functionality.