### PR TITLE
fix(test): Exclude Cloudberry from gpdb6_objects.sql execution

### DIFF
--- a/end_to_end/plugin_test.go
+++ b/end_to_end/plugin_test.go
@@ -156,7 +156,9 @@ var _ = Describe("End to End plugin tests", func() {
 			if (backupConn.Version.IsGPDB() && backupConn.Version.AtLeast("5")) || backupConn.Version.IsCBDB() {
 				testutils.ExecuteSQLFile(backupConn, "resources/gpdb5_objects.sql")
 			}
-			if (backupConn.Version.IsGPDB() && backupConn.Version.AtLeast("6")) || backupConn.Version.IsCBDB() {
+			// Exclude Cloudberry from gpdb6_objects.sql because it contains enum distribution keys
+			// which are not supported in Cloudberry database
+			if backupConn.Version.IsGPDB() && backupConn.Version.AtLeast("6") {
 				testutils.ExecuteSQLFile(backupConn, "resources/gpdb6_objects.sql")
 				defer testhelper.AssertQueryRuns(backupConn,
 					"DROP FOREIGN DATA WRAPPER fdw CASCADE;")
@@ -207,7 +209,9 @@ var _ = Describe("End to End plugin tests", func() {
 			if (backupConn.Version.IsGPDB() && backupConn.Version.AtLeast("5")) || backupConn.Version.IsCBDB() {
 				testutils.ExecuteSQLFile(backupConn, "resources/gpdb5_objects.sql")
 			}
-			if (backupConn.Version.IsGPDB() && backupConn.Version.AtLeast("6")) || backupConn.Version.IsCBDB() {
+			// Exclude Cloudberry from gpdb6_objects.sql because it contains enum distribution keys
+			// which are not supported in Cloudberry database
+			if backupConn.Version.IsGPDB() && backupConn.Version.AtLeast("6") {
 				testutils.ExecuteSQLFile(backupConn, "resources/gpdb6_objects.sql")
 				defer testhelper.AssertQueryRuns(backupConn,
 					"DROP FOREIGN DATA WRAPPER fdw CASCADE;")


### PR DESCRIPTION
Cloudberry database does not support enum types as distribution keys. The gpdb6_objects.sql file contains a legacy_enum table that uses an enum column as distribution key, causing test failures in Cloudberry environments.

Updated plugin tests to only execute GPDB 6+ specific objects on actual GPDB 6+ installations, while Cloudberry continues using GPDB 5+ compatible objects without enum distribution keys.

See: https://github.com/apache/cloudberry/issues/1300
