### PR TITLE
docs: Update S3 plugin repository link to Apache Cloudberry

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -32,7 +32,7 @@ options:
 ```
 
 ## Available plugins
-[gpbackup_s3_plugin](https://github.com/greenplum-db/gpbackup-s3-plugin): Allows users to back up their Greenplum Database to Amazon S3.
+[gpbackup_s3_plugin](https://github.com/apache/cloudberry-gpbackup-s3-plugin): Allows users to back up their Greenplum Database to Amazon S3.
 
 ## Developing plugins
 


### PR DESCRIPTION
Updated gpbackup_s3_plugin repository URL from greenplum-db organization to apache/cloudberry-gpbackup-s3-plugin to reflect the plugin's migration to the Apache Cloudberry project.